### PR TITLE
Check for Erdiko class existing before using it.

### DIFF
--- a/src/erdiko/shopify/Shopify.php
+++ b/src/erdiko/shopify/Shopify.php
@@ -19,7 +19,9 @@ class Shopify {
 		$this->api_key = $api_key;
 		$this->secret = $secret;
 
-		\Erdiko::log(null, "$shop_domain, $token, $api_key, $secret");
+		if (class_exists('Erdiko')) {
+			\Erdiko::log(null, "$shop_domain, $token, $api_key, $secret");
+		}
 	}
 
 	public function setToken($token)


### PR DESCRIPTION
If Shopify class is meant to be used with or without Erdiko, this is a simple way to allow it.